### PR TITLE
Speed up uuidToPhysicalPath and uuidToObject.

### DIFF
--- a/news/11.breaking
+++ b/news/11.breaking
@@ -1,0 +1,5 @@
+``uuidToObject``, ``uuidToURL`` and ``uuidToCatalogBrain`` return None when you are not authorized.
+Previously you would get an Unauthorized error when calling these functions or trying to use the result.
+``uuidToPhysicalPath`` is the only function that does not check security:
+you get the path, whether you can see the object at that path or not.
+[maurits]

--- a/news/11.breaking
+++ b/news/11.breaking
@@ -1,5 +1,0 @@
-``uuidToObject``, ``uuidToURL`` and ``uuidToCatalogBrain`` return None when you are not authorized.
-Previously you would get an Unauthorized error when calling these functions or trying to use the result.
-``uuidToPhysicalPath`` is the only function that does not check security:
-you get the path, whether you can see the object at that path or not.
-[maurits]

--- a/news/11.feature
+++ b/news/11.feature
@@ -1,5 +1,6 @@
 Speed up ``uuidToPhysicalPath`` and ``uuidToObject``.
 Do this by using an IndexQuery to only query the UID index.
-Note: none of the functions check security.
-It is up to the caller to do this, if needed.
+Note: of the four functions in ``utils.py``, only ``uuidToObject`` checks the security.
+For the other functions, it is up to the caller to do this, if needed.
+We may change this in the future, but for now the behavior should be the same as in previous versions.
 [maurits]

--- a/news/11.feature
+++ b/news/11.feature
@@ -1,0 +1,3 @@
+Speed up uuidToPhysicalPath and uuidToObject.
+Do this by using an IndexQuery to only query the UID index.
+[maurits]

--- a/news/11.feature
+++ b/news/11.feature
@@ -1,4 +1,5 @@
 Speed up ``uuidToPhysicalPath`` and ``uuidToObject``.
 Do this by using an IndexQuery to only query the UID index.
-``uuidToPhysicalPath`` no longer checks security, ``uuidToObject`` still does.
+Note: none of the functions check security.
+It is up to the caller to do this, if needed.
 [maurits]

--- a/news/11.feature
+++ b/news/11.feature
@@ -1,3 +1,4 @@
-Speed up uuidToPhysicalPath and uuidToObject.
+Speed up ``uuidToPhysicalPath`` and ``uuidToObject``.
 Do this by using an IndexQuery to only query the UID index.
+``uuidToPhysicalPath`` no longer checks security, ``uuidToObject`` still does.
 [maurits]

--- a/plone/app/uuid/tests.py
+++ b/plone/app/uuid/tests.py
@@ -163,6 +163,23 @@ class IntegrationTestCase(unittest.TestCase):
         self.assertEqual(aq_base(d1), aq_base(uuidToObject(uuid)))
         self.assertIsNone(uuidToObject('unknown'))
 
+    def test_uuidToCatalogBrain(self):
+        from Acquisition import aq_base
+        from plone.uuid.interfaces import IUUID
+        from plone.app.uuid.utils import uuidToCatalogBrain
+
+        portal = self.layer['portal']
+        setRoles(portal, TEST_USER_ID, ['Manager'])
+
+        portal.invokeFactory('Document', 'd1')
+        portal.invokeFactory('Document', 'd2')
+
+        d1 = portal['d1']
+        uuid = IUUID(d1)
+
+        self.assertEqual('/'.join(d1.getPhysicalPath()), uuidToCatalogBrain(uuid).getPath())
+        self.assertIsNone(uuidToCatalogBrain('unknown'))
+
     def test_uuidToObject_private_published(self):
         from Acquisition import aq_base
         from plone.uuid.interfaces import IUUID

--- a/plone/app/uuid/tests.py
+++ b/plone/app/uuid/tests.py
@@ -3,11 +3,13 @@ from plone.app.testing import logout
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_PASSWORD
+from plone.testing.zope import Browser
 from plone.app.uuid.testing import PLONE_APP_UUID_FUNCTIONAL_TESTING
 from plone.app.uuid.testing import PLONE_APP_UUID_INTEGRATION_TESTING
 
 import os
 import time
+import transaction
 import unittest
 
 
@@ -226,10 +228,8 @@ class FunctionalTestCase(unittest.TestCase):
         d1 = portal['d1']
         uuid = IUUID(d1)
 
-        import transaction
         transaction.commit()
 
-        from plone.testing.z2 import Browser
         browser = Browser(app)
         browser.addHeader(
             'Authorization',
@@ -253,10 +253,8 @@ class FunctionalTestCase(unittest.TestCase):
         d1 = portal['d1']
         uuid = IUUID(d1)
 
-        import transaction
         transaction.commit()
 
-        from plone.testing.z2 import Browser
         browser = Browser(app)
         browser.addHeader(
             'Authorization',
@@ -273,10 +271,8 @@ class FunctionalTestCase(unittest.TestCase):
 
         setRoles(portal, TEST_USER_ID, ['Manager'])
 
-        import transaction
         transaction.commit()
 
-        from plone.testing.z2 import Browser
         browser = Browser(app)
         browser.handleErrors = False
         browser.addHeader(

--- a/plone/app/uuid/tests.py
+++ b/plone/app/uuid/tests.py
@@ -183,6 +183,18 @@ class IntegrationTestCase(unittest.TestCase):
         self.assertIsNone(uuidToCatalogBrain('unknown'))
 
     def test_access_private_published(self):
+        """Do the functions return both private and published items?
+
+        It might be logical to only return an object if the user is authorized
+        to view it.  But this is not good for all use cases.
+        For example, plone.app.linkintegrity needs to be able to check *all*
+        links and create relations for them, even when the current Editor
+        does not have permission to view all of them.
+
+        So for now, all functions return information without checking
+        permissions.  In the future, we could add an extra keyword argument:
+        'restricted/unrestricted=True/False'.
+        """
         from Acquisition import aq_base
         from plone.uuid.interfaces import IUUID
         from plone.app.uuid.utils import uuidToPhysicalPath
@@ -233,11 +245,12 @@ class IntegrationTestCase(unittest.TestCase):
         self.assertEqual(published_path, uuidToCatalogBrain(published_uuid).getPath())
         self.assertEqual(aq_base(published), aq_base(uuidToObject(published_uuid)))
 
-        # Anonymous cannot see the private item, except for the physical path.
+        # Currently, anonymous can also see the private item.
+        # See the docstring of this test method.
         self.assertEqual(private_path, uuidToPhysicalPath(private_uuid))
-        self.assertIsNone(uuidToURL(private_uuid))
-        self.assertIsNone(uuidToCatalogBrain(private_uuid))
-        self.assertIsNone(uuidToObject(private_uuid))
+        self.assertEqual(private_url, uuidToURL(private_uuid))
+        self.assertEqual(private_path, uuidToCatalogBrain(private_uuid).getPath())
+        self.assertEqual(aq_base(private), aq_base(uuidToObject(private_uuid)))
 
 
 class FunctionalTestCase(unittest.TestCase):

--- a/plone/app/uuid/tests.py
+++ b/plone/app/uuid/tests.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from AccessControl import Unauthorized
 from plone.app.testing import logout
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -245,12 +246,18 @@ class IntegrationTestCase(unittest.TestCase):
         self.assertEqual(published_path, uuidToCatalogBrain(published_uuid).getPath())
         self.assertEqual(aq_base(published), aq_base(uuidToObject(published_uuid)))
 
-        # Currently, anonymous can also see the private item.
+        # Currently, anonymous can also see the private item with most functions.
         # See the docstring of this test method.
+        # But: when you get a brain with unrestrictedSearchResults,
+        # the getObject may fail.
         self.assertEqual(private_path, uuidToPhysicalPath(private_uuid))
         self.assertEqual(private_url, uuidToURL(private_uuid))
-        self.assertEqual(private_path, uuidToCatalogBrain(private_uuid).getPath())
-        self.assertEqual(aq_base(private), aq_base(uuidToObject(private_uuid)))
+        brain = uuidToCatalogBrain(private_uuid)
+        self.assertEqual(private_path, brain.getPath())
+        with self.assertRaises(Unauthorized):
+            brain.getObject()
+        with self.assertRaises(Unauthorized):
+            uuidToObject(private_uuid)
 
 
 class FunctionalTestCase(unittest.TestCase):

--- a/plone/app/uuid/tests.py
+++ b/plone/app/uuid/tests.py
@@ -69,6 +69,7 @@ class IntegrationTestCase(unittest.TestCase):
         from plone.app.uuid.utils import uuidToPhysicalPath
         from plone.app.uuid.utils import uuidToURL
         from plone.app.uuid.utils import uuidToObject
+        from plone.app.uuid.utils import uuidToCatalogBrain
 
         portal = self.layer['portal']
         setRoles(portal, TEST_USER_ID, ['Manager'])
@@ -105,6 +106,12 @@ class IntegrationTestCase(unittest.TestCase):
             self.assertEqual(info['obj'], aq_base(uuidToObject(uuid)))
         end = time.time()
         print("Time taken for uuidToObject: {}".format(end - start))
+
+        start = time.time()
+        for uuid, info in uuids.items():
+            self.assertEqual(info['path'], uuidToCatalogBrain(uuid).getPath())
+        end = time.time()
+        print("Time taken for uuidToCatalogBrain: {}".format(end - start))
 
     def test_uuidToURL(self):
         from plone.uuid.interfaces import IUUID

--- a/plone/app/uuid/tests.py
+++ b/plone/app/uuid/tests.py
@@ -6,6 +6,7 @@ from plone.app.testing import TEST_USER_PASSWORD
 from plone.app.uuid.testing import PLONE_APP_UUID_FUNCTIONAL_TESTING
 from plone.app.uuid.testing import PLONE_APP_UUID_INTEGRATION_TESTING
 
+import os
 import time
 import unittest
 
@@ -76,7 +77,17 @@ class IntegrationTestCase(unittest.TestCase):
 
         start = time.time()
         uuids = {}
-        total = 40
+
+        # Read env variable to see how many items to create.
+        # If we have a variable, do some printing.
+        total = os.getenv("PLONE_APP_UUID_TEST_SPEED_TOTAL")
+        if total:
+            report = True
+            total = int(total)
+            print("Creating {} documents...".format(total))
+        else:
+            report = False
+            total = 40
         for i in range(total):
             doc_id = portal.invokeFactory('Document', 'd{}'.format(i))
             doc = portal[doc_id]
@@ -86,32 +97,37 @@ class IntegrationTestCase(unittest.TestCase):
                 'obj': aq_base(doc),
             }
         end = time.time()
-        print("Time taken to create {} items: {}".format(total, end - start))
+        if report:
+            print("Time taken to create {} items: {}".format(total, end - start))
 
         self.assertEqual(len(uuids), total)
         start = time.time()
         for uuid, info in uuids.items():
             self.assertEqual(info['path'], uuidToPhysicalPath(uuid))
         end = time.time()
-        print("Time taken for uuidToPhysicalPath: {}".format(end - start))
+        if report:
+            print("Time taken for uuidToPhysicalPath: {}".format(end - start))
 
         start = time.time()
         for uuid, info in uuids.items():
             self.assertEqual(info['url'], uuidToURL(uuid))
         end = time.time()
-        print("Time taken for uuidToURL: {}".format(end - start))
+        if report:
+            print("Time taken for uuidToURL: {}".format(end - start))
 
         start = time.time()
         for uuid, info in uuids.items():
             self.assertEqual(info['obj'], aq_base(uuidToObject(uuid)))
         end = time.time()
-        print("Time taken for uuidToObject: {}".format(end - start))
+        if report:
+            print("Time taken for uuidToObject: {}".format(end - start))
 
         start = time.time()
         for uuid, info in uuids.items():
             self.assertEqual(info['path'], uuidToCatalogBrain(uuid).getPath())
         end = time.time()
-        print("Time taken for uuidToCatalogBrain: {}".format(end - start))
+        if report:
+            print("Time taken for uuidToCatalogBrain: {}".format(end - start))
 
     def test_uuidToURL(self):
         from plone.uuid.interfaces import IUUID

--- a/plone/app/uuid/tests.py
+++ b/plone/app/uuid/tests.py
@@ -61,6 +61,7 @@ class IntegrationTestCase(unittest.TestCase):
 
         self.assertEqual('/'.join(d1.getPhysicalPath()),
                          uuidToPhysicalPath(uuid))
+        self.assertIsNone(uuidToPhysicalPath('unknown'))
 
     def test_speed(self):
         # I updated some of the utility functions to be a bit faster.
@@ -143,6 +144,7 @@ class IntegrationTestCase(unittest.TestCase):
         uuid = IUUID(d1)
 
         self.assertEqual(d1.absolute_url(), uuidToURL(uuid))
+        self.assertIsNone(uuidToURL('unknown'))
 
     def test_uuidToObject(self):
         from Acquisition import aq_base
@@ -159,6 +161,7 @@ class IntegrationTestCase(unittest.TestCase):
         uuid = IUUID(d1)
 
         self.assertEqual(aq_base(d1), aq_base(uuidToObject(uuid)))
+        self.assertIsNone(uuidToObject('unknown'))
 
     def test_uuidToObject_private_published(self):
         from Acquisition import aq_base

--- a/plone/app/uuid/utils.py
+++ b/plone/app/uuid/utils.py
@@ -10,6 +10,9 @@ def uuidToPhysicalPath(uuid):
     object. Will return None if the UUID can't be found.
 
     This version is four times faster than the original.
+    Downside: it no longer automatically checks if the user is allowed
+    to see the object at the path.  This is now the responsibility
+    of the caller.  See the updated code in uuidToObject.
     """
     site = getSite()
     if site is None:

--- a/plone/app/uuid/utils.py
+++ b/plone/app/uuid/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from AccessControl import Unauthorized
 from Products.CMFCore.utils import getToolByName
 from Products.ZCatalog.query import IndexQuery
 from zope.component.hooks import getSite
@@ -52,7 +53,16 @@ def uuidToObject(uuid):
     site = getSite()
     if site is None:
         return
-    return site.restrictedTraverse(path)
+    # Go to the parent of the item without restrictions.
+    split_path = path.split("/")
+    parent_path = split_path[:-1]
+    parent = site.unrestrictedTraverse(parent_path)
+    # Do check restrictions for the final object.
+    final_path = split_path[-1]
+    try:
+        return parent.restrictedTraverse(final_path)
+    except Unauthorized:
+        return
 
 
 def uuidToCatalogBrain(uuid):

--- a/plone/app/uuid/utils.py
+++ b/plone/app/uuid/utils.py
@@ -32,9 +32,9 @@ def uuidToPhysicalPath(uuid):
     object. Will return None if the UUID can't be found.
 
     This version is four times faster than the original.
-    Downside: it no longer automatically checks if the user is allowed
-    to see the object at the path.  This is now the responsibility
-    of the caller.  See the updated code in uuidToObject.
+
+    Note: the user may not be authorized to view the object at this path.
+    It is up to the caller to check this, if needed.
     """
     catalog = _catalog()
     if catalog is None:
@@ -59,6 +59,9 @@ def uuidToPhysicalPath(uuid):
 def uuidToURL(uuid):
     """Given a UUID, attempt to return the absolute URL of the underlying
     object. Will return None if the UUID can't be found.
+
+    Note: the user may not be authorized to view the object at the url.
+    It is up to the caller to check this, if needed.
     """
 
     brain = uuidToCatalogBrain(uuid)
@@ -71,6 +74,9 @@ def uuidToURL(uuid):
 def uuidToObject(uuid):
     """Given a UUID, attempt to return a content object. Will return
     None if the UUID can't be found.
+
+    Note: the user may not be authorized to view the object.
+    It is up to the caller to check this, if needed.
     """
     path = uuidToPhysicalPath(uuid)
     if not path:
@@ -78,24 +84,19 @@ def uuidToObject(uuid):
     site = getSite()
     if site is None:
         return
-    # Go to the parent of the item without restrictions.
-    parent_path, final_path = path.rpartition("/")[::2]
-    parent = site.unrestrictedTraverse(parent_path)
-    # Do check restrictions for the final object.
-    try:
-        return parent.restrictedTraverse(final_path)
-    except Unauthorized:
-        return
+    return site.unrestrictedTraverse(path)
 
 
 def uuidToCatalogBrain(uuid):
     """Given a UUID, attempt to return a catalog brain.
+
+    Note: the user may not be authorized to view the object for this brain.
+    It is up to the caller to check this, if needed.
     """
     catalog = _catalog()
     if catalog is None:
         return
-    # Note: until plone.app.uuid 2.x, we called unrestrictedSearchResults here.
-    result = catalog.searchResults(UID=uuid)
+    result = catalog.unrestrictedSearchResults(UID=uuid)
     if len(result) != 1:
         return None
 

--- a/plone/app/uuid/utils.py
+++ b/plone/app/uuid/utils.py
@@ -94,7 +94,8 @@ def uuidToCatalogBrain(uuid):
     catalog = _catalog()
     if catalog is None:
         return
-    result = catalog.unrestrictedSearchResults(UID=uuid)
+    # Note: until plone.app.uuid 2.x, we called unrestrictedSearchResults here.
+    result = catalog.searchResults(UID=uuid)
     if len(result) != 1:
         return None
 

--- a/plone/app/uuid/utils.py
+++ b/plone/app/uuid/utils.py
@@ -79,11 +79,9 @@ def uuidToObject(uuid):
     if site is None:
         return
     # Go to the parent of the item without restrictions.
-    split_path = path.split("/")
-    parent_path = split_path[:-1]
+    parent_path, final_path = path.rpartition("/")[::2]
     parent = site.unrestrictedTraverse(parent_path)
     # Do check restrictions for the final object.
-    final_path = split_path[-1]
     try:
         return parent.restrictedTraverse(final_path)
     except Unauthorized:

--- a/plone/app/uuid/utils.py
+++ b/plone/app/uuid/utils.py
@@ -84,7 +84,11 @@ def uuidToObject(uuid):
     site = getSite()
     if site is None:
         return
-    return site.unrestrictedTraverse(path)
+    # Go to the parent of the item without restrictions.
+    parent_path, final_path = path.rpartition("/")[::2]
+    parent = site.unrestrictedTraverse(parent_path)
+    # Do check restrictions for the final object.
+    return parent.restrictedTraverse(final_path)
 
 
 def uuidToCatalogBrain(uuid):

--- a/plone/app/uuid/utils.py
+++ b/plone/app/uuid/utils.py
@@ -1,18 +1,33 @@
 # -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
+from Products.ZCatalog.query import IndexQuery
 from zope.component.hooks import getSite
 
 
 def uuidToPhysicalPath(uuid):
     """Given a UUID, attempt to return the absolute path of the underlying
     object. Will return None if the UUID can't be found.
+
+    This version is four times faster than the original.
     """
-
-    brain = uuidToCatalogBrain(uuid)
-    if brain is None:
+    site = getSite()
+    if site is None:
         return None
-
-    return brain.getPath()
+    catalog = getToolByName(site, 'portal_catalog', None)
+    if catalog is None:
+        return None
+    index = catalog.Indexes["UID"]
+    # This works even faster, but uses a private attribute:
+    # rid = index._index.get(uuid)
+    # if not rid:
+    #     return
+    query = IndexQuery({"UID": uuid}, "UID")
+    result = index.query_index(query)
+    if not result:
+        return
+    rid = result[0]
+    path = catalog.getpath(rid)
+    return path
 
 
 def uuidToURL(uuid):
@@ -31,12 +46,13 @@ def uuidToObject(uuid):
     """Given a UUID, attempt to return a content object. Will return
     None if the UUID can't be found.
     """
-
-    brain = uuidToCatalogBrain(uuid)
-    if brain is None:
-        return None
-
-    return brain.getObject()
+    path = uuidToPhysicalPath(uuid)
+    if not path:
+        return
+    site = getSite()
+    if site is None:
+        return
+    return site.restrictedTraverse(path)
 
 
 def uuidToCatalogBrain(uuid):

--- a/plone/app/uuid/utils.py
+++ b/plone/app/uuid/utils.py
@@ -21,15 +21,18 @@ def uuidToPhysicalPath(uuid):
     if catalog is None:
         return None
     index = catalog.Indexes["UID"]
-    # This works even faster, but uses a private attribute:
-    # rid = index._index.get(uuid)
-    # if not rid:
-    #     return
-    query = IndexQuery({"UID": uuid}, "UID")
-    result = index.query_index(query)
-    if not result:
+    try:
+        # This uses a private attribute, so be careful.
+        rid = index._index.get(uuid)
+    except AttributeError:
+        # Fall back to IndexQuery.
+        query = IndexQuery({"UID": uuid}, "UID")
+        result = index.query_index(query)
+        if not result:
+            return
+        rid = result[0]
+    if not rid:
         return
-    rid = result[0]
     path = catalog.getpath(rid)
     return path
 

--- a/plone/app/uuid/utils.py
+++ b/plone/app/uuid/utils.py
@@ -18,9 +18,12 @@ def _catalog():
     except AttributeError:
         site = getSite()
         if site is None:
-            request._catalog = None
+            if request is not None:
+                request._catalog = None
             return
-        catalog = request._catalog = getToolByName(site, 'portal_catalog', None)
+        catalog = getToolByName(site, 'portal_catalog', None)
+        if request is not None:
+            request._catalog = catalog
         return catalog
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.0.3.dev0'
+version = '3.0.0a1.dev0'
 
 long_description = '{0}\n{1}'.format(
     open('README.rst').read(),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '3.0.0a1.dev0'
+version = '2.1.0.dev0'
 
 long_description = '{0}\n{1}'.format(
     open('README.rst').read(),
@@ -19,12 +19,10 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Plone',
-        'Framework :: Plone :: 5.2',
         'Framework :: Plone :: 6.0',
         'Framework :: Plone :: Core',
         "License :: OSI Approved :: GNU General Public License (GPL)",
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
Do this by using an `IndexQuery` to only query the UID index. This means we do not need to get a full brain, which takes long.

Before, in a `test_speed` run with 400 items:

```
Time taken for uuidToPhysicalPath: 0.21054577827453613
Time taken for uuidToObject: 0.4477109909057617
```

Afterwards:

```
Time taken for uuidToPhysicalPath: 0.030041933059692383
Time taken for uuidToObject: 0.09154772758483887
```

So this is 5 to 7 times as fast.

I tried changing `uuidToURL` along the same lines, but in both cases this was about the same, 0.15 seconds.
