### PR TITLE
Add optional security check for uuidToObject

### DIFF
--- a/news/13.bugfix
+++ b/news/13.bugfix
@@ -1,0 +1,1 @@
+Add optional security check for uuidToObject

--- a/news/13.bugfix
+++ b/news/13.bugfix
@@ -1,1 +1,1 @@
-Add optional security check for uuidToObject
+Add optional security check for uuidToObject [anirudhhkashyap]

--- a/plone/app/uuid/tests.py
+++ b/plone/app/uuid/tests.py
@@ -245,11 +245,14 @@ class IntegrationTestCase(unittest.TestCase):
         self.assertEqual(published_url, uuidToURL(published_uuid))
         self.assertEqual(published_path, uuidToCatalogBrain(published_uuid).getPath())
         self.assertEqual(aq_base(published), aq_base(uuidToObject(published_uuid)))
+    
 
         # Currently, anonymous can also see the private item with most functions.
         # See the docstring of this test method.
         # But: when you get a brain with unrestrictedSearchResults,
         # the getObject may fail.
+        # Object can be accessed when unrestricted flag is set to True
+        self.assertEqual(aq_base(private), aq_base(uuidToObject(private_uuid, True)))
         self.assertEqual(private_path, uuidToPhysicalPath(private_uuid))
         self.assertEqual(private_url, uuidToURL(private_uuid))
         brain = uuidToCatalogBrain(private_uuid)

--- a/plone/app/uuid/utils.py
+++ b/plone/app/uuid/utils.py
@@ -71,12 +71,14 @@ def uuidToURL(uuid):
     return brain.getURL()
 
 
-def uuidToObject(uuid):
+def uuidToObject(uuid, unrestricted = False):
     """Given a UUID, attempt to return a content object. Will return
     None if the UUID can't be found.
 
     Note: the user may not be authorized to view the object.
     It is up to the caller to check this, if needed.
+
+    If the author is authorised to view the object, unrestricted flag should be set to True
     """
     path = uuidToPhysicalPath(uuid)
     if not path:
@@ -88,6 +90,9 @@ def uuidToObject(uuid):
     parent_path, final_path = path.rpartition("/")[::2]
     parent = site.unrestrictedTraverse(parent_path)
     # Do check restrictions for the final object.
+    # Check if the object has restrictions
+    if unrestricted:
+        return parent.unrestrictedTraverse(final_path)
     return parent.restrictedTraverse(final_path)
 
 


### PR DESCRIPTION
Fixes [#13](https://github.com/plone/plone.app.uuid/issues/13)

Changes:
- Optional Security Check for objects 

Sometimes the user is allowed to view the object. The unrestricted flag is used to check this. It is False by default and when set to True allows the object to be accessed.